### PR TITLE
Add docker-compose for development services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+  dashboard:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+    volumes:
+      - ./frontend:/app
+  shop-ui:
+    build: ./demo-shop
+    ports:
+      - "3001:3001"
+    depends_on:
+      - backend
+    volumes:
+      - ./demo-shop:/app


### PR DESCRIPTION
## Summary
- add docker-compose.yml defining backend, dashboard, and shop-ui services
- map ports and volumes for live reload and service dependencies

## Testing
- `python - <<'PY'
import yaml,sys
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689141ad2d10832e8eec551a1a135d02