### PR TITLE
Add backend Dockerfile and requirements

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+ENTRYPOINT ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+passlib[bcrypt]
+python-jose[cryptography]
+python-multipart
+numpy
+scikit-learn


### PR DESCRIPTION
## Summary
- Add Dockerfile for backend using python:3.11-slim, installing requirements and running uvicorn on port 8000.
- Introduce requirements.txt with FastAPI, SQLAlchemy, and other dependencies.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689143447008832eaf121cfa9e278c7a