### PR TITLE
docs: update run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ split into three main parts:
 
 * **backend/** – FastAPI application providing authentication, shopping and
   metrics endpoints.
-* **frontend/** – React dashboard demonstrating the attacks and defences.
+* **dashboard/** – React dashboard demonstrating the attacks and defences.
 * **shop-ui/** – simple static shop used by the demos.
 
 ## Running the backend
@@ -14,9 +14,27 @@ split into three main parts:
 ```bash
 pip install fastapi uvicorn sqlalchemy pydantic passlib[bcrypt] python-jose \
     numpy scikit-learn
-uvicorn backend.app:app --reload
+uvicorn backend.main:app --reload
 ```
 
-The frontend code can be integrated into any React build process and the demo
-shop can be opened directly in a browser by loading `shop-ui/index.html`.
+## Running all services with Docker Compose
+
+To start the backend API, React dashboard, and demo shop together run:
+
+```bash
+docker-compose up --build
+```
+
+This exposes the following services:
+
+* Backend API – http://localhost:8000
+* React dashboard – http://localhost:3000
+* Demo shop – http://localhost:3001
+
+## Requirements for the dashboard and shop
+
+The React dashboard in `dashboard/` requires a Node.js environment with npm to
+install dependencies (`npm install`) and run (`npm start`) if not using Docker.
+The demo shop in `shop-ui/` is a static site that can be served by any web
+server or opened directly in a browser via `shop-ui/index.html`.
 


### PR DESCRIPTION
## Summary
- fix backend startup command to use `backend.main`
- add Docker Compose workflow and service URLs
- outline requirements for the React dashboard and demo shop

## Testing
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_68914d8fc574832eba30a0bbe5e1e2a6