### PR TITLE
Use pydantic-settings for configuration

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
@@ -9,7 +9,6 @@ class Settings(BaseSettings):
     ANOMALY_DETECTION_ENABLED: bool = True
     ANOMALY_MODEL: str = "isolation_forest"
 
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 settings = Settings()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
+pydantic-settings
 passlib[bcrypt]
 python-jose[cryptography]
 python-multipart


### PR DESCRIPTION
## Summary
- migrate backend settings to pydantic-settings and configure .env loading via SettingsConfigDict
- add `pydantic-settings` dependency

## Testing
- `pip install -r backend/requirements.txt`
- `python -m uvicorn backend.main:app --reload`


------
https://chatgpt.com/codex/tasks/task_e_68915e214da0832e81ffd6174725874d